### PR TITLE
for the time being, this excludes the mcp-inspector, since we do not …

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This repository contains a Docker Compose setup to deploy a set of services for 
 ## Prerequisites
 - Ensure Docker and Docker Compose are installed on your machine.
 - Create necessary directories for volume bindings if they do not exist before running the services.
+- MCP Inspector currently does not have a reliable Docker image. Use the auxiliary setup:
+  - Install Node.js version 24.x or later.
+  - Run the following command to start MCP Inspector:
+    ```bash
+    npx @modelcontextprotocol/inspector
+    ```
 
 ### Directory and File Setup for Anything LLM
 To avoid errors during the Docker Compose setup, ensure that the necessary directories and files for Anything LLM are prepared:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,23 @@
 version: '3.8'
 
 services:
-  mcp-inspector:
-    image: mcp-inspector-image
-    ports:
-      - "6274:6274" # Mapping the MCP Inspector client port
-      - "6277:6277" # Mapping the MCP Inspector server port
-    restart: unless-stopped
-    container_name: mcp-inspector
-    networks:
-      - my_network
-    environment:
-      CLIENT_PORT: 6274
-      SERVER_PORT: 6277
+  # mcp-inspector:
+  #   image: mcp-inspector-image
+  #   ports:
+  #     - "6274:6274" # Mapping the MCP Inspector client port
+  #     - "6277:6277" # Mapping the MCP Inspector server port
+  #   restart: unless-stopped
+  #   container_name: mcp-inspector
+  #   networks:
+  #     - my_network
+  #   environment:
+  #     CLIENT_PORT: 6274
+  #     SERVER_PORT: 6277
+  # 
+  # NOTE: The Docker image for MCP Inspector is not ready yet. 
+  # Users can run the MCP Inspector using an auxiliary script that requires:
+  # * Node.js 24.x or later
+  # * Command to execute: npx @modelcontextprotocol/inspector
 
   hb-int-hub:
     image: highbyte:4.2.0


### PR DESCRIPTION
…have a reliable docker image for it.